### PR TITLE
修复FinalDb OneToMany无效的问题

### DIFF
--- a/src/net/tsz/afinal/FinalDb.java
+++ b/src/net/tsz/afinal/FinalDb.java
@@ -609,7 +609,7 @@ public class FinalDb {
 
 					if (isFind) {
 						List<?> list = findAllByWhere(one.getOneClass(),
-								one.getColumn() + "='" + id + "'");
+                                one.getColumn() + "=" + id);
 						if (list != null) {
 							/* 如果是OneToManyLazyLoader泛型，则执行灌入懒加载数据 */
 							if (one.getDataType() == OneToManyLazyLoader.class) {
@@ -888,10 +888,12 @@ public class FinalDb {
 			this.mDbUpdateListener = dbUpdateListener;
 		}
 
-		public void onCreate(SQLiteDatabase db) {
+		@Override
+        public void onCreate(SQLiteDatabase db) {
 		}
 
-		public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
+		@Override
+        public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
 			if (mDbUpdateListener != null) {
 				mDbUpdateListener.onUpgrade(db, oldVersion, newVersion);
 			} else { // 清空所有的数据信息


### PR DESCRIPTION
修复`FinalDb.loadOneToMany(T entity, Class<T> clazz, Class<?>... findClass)`方法无效的问题,  
顺带修复OneToMany懒加载中`Parent.getChildren().getList().size()`总为0的问题.
