### PR TITLE
Fix Issue #91

### DIFF
--- a/src/net/tsz/afinal/FinalBitmap.java
+++ b/src/net/tsz/afinal/FinalBitmap.java
@@ -756,7 +756,7 @@ public class FinalBitmap {
 		 public int memCacheSize;//内存缓存百分比
 		 public int diskCacheSize;//磁盘百分比
 		 public int poolSize = 3;//默认的线程池线程并发数量
-		 public boolean recycleImmediately = true;//是否立即回收内存
+		 public boolean recycleImmediately = false;//是否立即回收内存
 		
 		 public FinalBitmapConfig(Context context) {
 				defaultDisplayConfig = new BitmapDisplayConfig();


### PR DESCRIPTION
如果不做任何设置，FinalBitmap.configRecycleImmediately(boolean)的参数默认值是true，那么会导致每次缓存的图片将从内存中清除，而从磁盘中读取缓存，会造成卡顿。特别是在图片较多的Listview中，请大家注意！
