### PR TITLE
解决数据库db_version升级时，报出nullpointerexception。主要是FinalDb里面的dropDb方法，需要把db…

### DIFF
--- a/src/net/tsz/afinal/FinalDb.java
+++ b/src/net/tsz/afinal/FinalDb.java
@@ -376,8 +376,11 @@ public class FinalDb {
 
 	/**
 	 * 删除所有数据表
+	 * Changed by yinchuandong 
+	 * In the old version, the variable 'db' is global and is null initially, however, <br/>
+	 * when onUpgrade function is called, the db is passed as local variable 
 	 */
-	public void dropDb() {
+	public void dropDb(SQLiteDatabase db) {
 		Cursor cursor = db.rawQuery(
 				"SELECT name FROM sqlite_master WHERE type ='table' AND name != 'sqlite_sequence'", null);
 		if (cursor != null) {
@@ -891,7 +894,7 @@ public class FinalDb {
 			if (mDbUpdateListener != null) {
 				mDbUpdateListener.onUpgrade(db, oldVersion, newVersion);
 			} else { // 清空所有的数据信息
-				dropDb();
+				dropDb(db);
 			}
 		}
 


### PR DESCRIPTION
解决数据库db_version升级时，报出nullpointerexception。主要是FinalDb里面的dropDb方法，需要把db当做参数传过去，而不能使用全局的db 变量。
